### PR TITLE
Release version 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "command-error"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "indoc",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 
 [package]
 name = "command-error"
-version = "0.2.0"
+version = "0.2.1"
 description = "Detailed error messages and status checking for `std::process::Command`"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Update version to 0.2.1 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.