### PR TITLE
Display `current_dir` and `envs` in commands

### DIFF
--- a/src/utf8_program_and_args.rs
+++ b/src/utf8_program_and_args.rs
@@ -20,15 +20,44 @@ use crate::CommandDisplay;
 ///     displayed.to_string(),
 ///     "echo 'puppy doggy'"
 /// );
+///
+/// let mut command = Command::new("echo");
+/// command.arg("doggy")
+///     .current_dir("/puppy")
+///     .env("COLOR", "GOLDEN")
+///     .env_remove("STINKY");
+/// let displayed: Utf8ProgramAndArgs = (&command).into();
+/// assert_eq!(
+///     displayed.to_string(),
+///     "cd /puppy && COLOR=GOLDEN STINKY= echo doggy"
+/// );
 /// ```
 #[derive(Debug, Clone)]
 pub struct Utf8ProgramAndArgs {
+    current_dir: Option<String>,
+    envs: Vec<(String, Option<String>)>,
     program: String,
     args: Vec<String>,
 }
 
 impl Display for Utf8ProgramAndArgs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(current_dir) = &self.current_dir {
+            write!(f, "cd {} && ", shell_words::quote(current_dir))?;
+        }
+
+        for (key, value) in self.envs.iter() {
+            // TODO: Should I care about spaces in environment variable names???
+            write!(
+                f,
+                "{key}={} ",
+                value
+                    .as_deref()
+                    .map(|value| shell_words::quote(value))
+                    .unwrap_or_default()
+            )?;
+        }
+
         write!(f, "{}", shell_words::quote(&self.program))?;
         if !self.args.is_empty() {
             write!(f, " {}", shell_words::join(&self.args))?;
@@ -54,6 +83,18 @@ impl CommandDisplay for Utf8ProgramAndArgs {
 impl<'a> From<&'a Command> for Utf8ProgramAndArgs {
     fn from(command: &'a Command) -> Self {
         Utf8ProgramAndArgs {
+            current_dir: command
+                .get_current_dir()
+                .map(|path| path.to_string_lossy().into_owned()),
+            envs: command
+                .get_envs()
+                .map(|(key, value)| {
+                    (
+                        key.to_string_lossy().into_owned(),
+                        value.map(|value| value.to_string_lossy().into_owned()),
+                    )
+                })
+                .collect(),
             program: command.get_program().to_string_lossy().into_owned(),
             args: command
                 .get_args()


### PR DESCRIPTION
Teach `Utf8ProgramAndArgs` about `current_dir` and `envs` when displaying commands.

Closes #21