### PR TITLE
Release version 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "command-error"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dyn-clone",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 
 [package]
 name = "command-error"
-version = "0.5.0"
+version = "0.6.0"
 description = "Detailed error messages and status checking for `std::process::Command`"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Update version to 0.6.0 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.