### PR TITLE
ChildContext::command: return type is `'static`

### DIFF
--- a/src/child_context.rs
+++ b/src/child_context.rs
@@ -39,7 +39,7 @@ impl<C> ChildContext<C> {
     }
 
     /// Get a reference to the command which produced this child process.
-    pub fn command(&self) -> &(dyn CommandDisplay + Send + Sync) {
+    pub fn command(&self) -> &(dyn CommandDisplay + Send + Sync + 'static) {
         self.command.borrow()
     }
 }


### PR DESCRIPTION
It turns out `Box<dyn Trait>` is `Box<dyn Trait + 'static>` but `&(dyn Trait)` is not `&(dyn Trait + 'static)`.